### PR TITLE
Update github.com/caffix/queue to its latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/caffix/eventbus
 
 go 1.15
 
-require github.com/caffix/queue v0.0.0-20201229193127-fbd8f53cfd6a
+require github.com/caffix/queue v0.0.0-20210301043549-e3b360b69730

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
-github.com/caffix/queue v0.0.0-20201218023921-5af3e766d2a5 h1:WGmE5LxnSuwI3k93eK9+djzAidn/202q4Bw+X9l4vX8=
-github.com/caffix/queue v0.0.0-20201218023921-5af3e766d2a5/go.mod h1:EGrMYDMC3oIYDWaLGKWMypHkg/vEBDqxbz2guAlY0Wk=
-github.com/caffix/queue v0.0.0-20201229193127-fbd8f53cfd6a h1:3qpGeJifrz62wVY4yHfhnd4gygtejkxmqM+GiUXOTK8=
-github.com/caffix/queue v0.0.0-20201229193127-fbd8f53cfd6a/go.mod h1:EGrMYDMC3oIYDWaLGKWMypHkg/vEBDqxbz2guAlY0Wk=
+github.com/caffix/queue v0.0.0-20210301043549-e3b360b69730 h1:9scnPUlS5CesLD16QQ0Q0+BGvgLiE4ziwsm4XvmZKG8=
+github.com/caffix/queue v0.0.0-20210301043549-e3b360b69730/go.mod h1:EGrMYDMC3oIYDWaLGKWMypHkg/vEBDqxbz2guAlY0Wk=
+github.com/caffix/stringset v0.0.0-20201218015502-4f60634ff035 h1:wFUL+cdCb5erB1HJHGYrtm5i6Y2LYpCq3wFef7XNii4=
 github.com/caffix/stringset v0.0.0-20201218015502-4f60634ff035/go.mod h1:28GU9FTlJHzfjrFJ5Ep7vmXNkSSM3JF0miNt7ZM9V5w=


### PR DESCRIPTION
The latest version of `github.com/caffix/queue` includes an important performance
improvement from which this library should greatly benefit.